### PR TITLE
Launch description on robot

### DIFF
--- a/turtlebot4_bringup/launch/lite.launch.py
+++ b/turtlebot4_bringup/launch/lite.launch.py
@@ -48,7 +48,7 @@ def generate_launch_description():
     oakd_launch_file = PathJoinSubstitution(
         [pkg_turtlebot4_bringup, 'launch', 'oakd.launch.py'])
     description_launch_file = PathJoinSubstitution(
-        [pkg_turtlebot4_description, 'launch', 'description.launch.py']
+        [pkg_turtlebot4_description, 'launch', 'robot_description.launch.py']
     )
 
     lite_launch = IncludeLaunchDescription(

--- a/turtlebot4_bringup/launch/lite.launch.py
+++ b/turtlebot4_bringup/launch/lite.launch.py
@@ -28,6 +28,7 @@ def generate_launch_description():
 
     pkg_turtlebot4_bringup = get_package_share_directory('turtlebot4_bringup')
     pkg_turtlebot4_diagnostics = get_package_share_directory('turtlebot4_diagnostics')
+    pkg_turtlebot4_description = get_package_share_directory('turtlebot4_description')
 
     param_file_cmd = DeclareLaunchArgument(
         'param_file',
@@ -46,6 +47,9 @@ def generate_launch_description():
         [pkg_turtlebot4_bringup, 'launch', 'rplidar.launch.py'])
     oakd_launch_file = PathJoinSubstitution(
         [pkg_turtlebot4_bringup, 'launch', 'oakd.launch.py'])
+    description_launch_file = PathJoinSubstitution(
+        [pkg_turtlebot4_description, 'launch', 'description.launch.py']
+    )
 
     lite_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([turtlebot4_robot_launch_file]),
@@ -58,6 +62,10 @@ def generate_launch_description():
     oakd_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([oakd_launch_file]),
         launch_arguments=[('camera_model', 'OAK-D-LITE')])
+    description_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([description_launch_file]),
+        launch_arguments=[('model', 'lite')]
+    )
 
     ld = LaunchDescription()
     ld.add_action(param_file_cmd)
@@ -65,4 +73,5 @@ def generate_launch_description():
     ld.add_action(diagnostics_launch)
     ld.add_action(rplidar_launch)
     ld.add_action(oakd_launch)
+    ld.add_action(description_launch)
     return ld

--- a/turtlebot4_bringup/launch/oakd.launch.py
+++ b/turtlebot4_bringup/launch/oakd.launch.py
@@ -76,51 +76,15 @@ def generate_launch_description():
         'LRchecktresh',
         default_value=LRchecktresh)
 
-    stereo_node = Node(
+    rgb_stereo_node = Node(
             package='depthai_examples',
-            executable='stereo_node',
+            executable='rgb_stereo_node',
             output='screen',
             parameters=[{'camera_name': camera_name},
                         {'mode': mode},
                         {'lrcheck': lrcheck},
                         {'extended': extended},
                         {'subpixel': subpixel}])
-
-    oakd_left_standard_stf = Node(
-            name='oakd_standard_stf',
-            package='tf2_ros',
-            executable='static_transform_publisher',
-            output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'oakd_pro_link', 'oak_left_camera_optical_frame'],
-            condition=LaunchConfigurationEquals('model', 'standard')
-        )
-
-    oakd_right_standard_stf = Node(
-            name='oakd_standard_stf',
-            package='tf2_ros',
-            executable='static_transform_publisher',
-            output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'oakd_pro_link', 'oak_right_camera_optical_frame'],
-            condition=LaunchConfigurationEquals('model', 'standard')
-        )
-
-    oakd_rgb_standard_stf = Node(
-            name='oakd_standard_stf',
-            package='tf2_ros',
-            executable='static_transform_publisher',
-            output='screen',
-            arguments=['0', '0', '0', '0', '0', '0', 'oakd_pro_link', 'oak_rgb_camera_optical_frame'],
-            condition=LaunchConfigurationEquals('model', 'standard')
-        )
-
-    oakd_lite_stf = Node(
-            name='oakd_lite_stf',
-            package='tf2_ros',
-            executable='static_transform_publisher',
-            output='screen',
-            arguments=['-0.09', '0', '0.18588622', '0', '0', '0', 'base_link', 'oak-d-base-frame'],
-            condition=LaunchConfigurationEquals('model', 'lite')
-        )
 
     ld = LaunchDescription()
     ld.add_action(robot_model)
@@ -133,10 +97,6 @@ def generate_launch_description():
     ld.add_action(declare_confidence_cmd)
     ld.add_action(declare_LRchecktresh_cmd)
 
-    ld.add_action(stereo_node)
-    ld.add_action(oakd_left_standard_stf)
-    ld.add_action(oakd_right_standard_stf)
-    ld.add_action(oakd_rgb_standard_stf)
-    ld.add_action(oakd_lite_stf)
+    ld.add_action(rgb_stereo_node)
 
     return ld

--- a/turtlebot4_bringup/launch/oakd.launch.py
+++ b/turtlebot4_bringup/launch/oakd.launch.py
@@ -91,7 +91,7 @@ def generate_launch_description():
             package='tf2_ros',
             executable='static_transform_publisher',
             output='screen',
-            arguments=['-0.0596', '0', '0.17933', '0', '0', '0', 'base_link', 'oak_left_camera_optical_frame'],
+            arguments=['0', '0', '0', '0', '0', '0', 'oakd_pro_link', 'oak_left_camera_optical_frame'],
             condition=LaunchConfigurationEquals('model', 'standard')
         )
 
@@ -100,7 +100,7 @@ def generate_launch_description():
             package='tf2_ros',
             executable='static_transform_publisher',
             output='screen',
-            arguments=['-0.0596', '0', '0.17933', '0', '0', '0', 'base_link', 'oak_right_camera_optical_frame'],
+            arguments=['0', '0', '0', '0', '0', '0', 'oakd_pro_link', 'oak_right_camera_optical_frame'],
             condition=LaunchConfigurationEquals('model', 'standard')
         )
 
@@ -109,7 +109,7 @@ def generate_launch_description():
             package='tf2_ros',
             executable='static_transform_publisher',
             output='screen',
-            arguments=['-0.0596', '0', '0.17933', '0', '0', '0', 'base_link', 'oak_rgb_camera_optical_frame'],
+            arguments=['0', '0', '0', '0', '0', '0', 'oakd_pro_link', 'oak_rgb_camera_optical_frame'],
             condition=LaunchConfigurationEquals('model', 'standard')
         )
 

--- a/turtlebot4_bringup/launch/oakd.launch.py
+++ b/turtlebot4_bringup/launch/oakd.launch.py
@@ -25,24 +25,12 @@ from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.conditions import LaunchConfigurationEquals
 from launch.substitutions import LaunchConfiguration
 
-import launch_ros.actions
+from launch_ros.actions import Node
 import launch_ros.descriptions
 
 
 def generate_launch_description():
-    urdf_launch_dir = os.path.join(get_package_share_directory('depthai_bridge'), 'launch')
-
-    camera_model = LaunchConfiguration('camera_model',  default='OAK-D')
     camera_name = LaunchConfiguration('camera_name',   default='oak')
-    base_frame = LaunchConfiguration('base_frame',    default='oak-d_frame')
-    parent_frame = LaunchConfiguration('parent_frame',  default='oak-d-base-frame')
-
-    cam_pos_x = LaunchConfiguration('cam_pos_x',     default='0.0')
-    cam_pos_y = LaunchConfiguration('cam_pos_y',     default='0.0')
-    cam_pos_z = LaunchConfiguration('cam_pos_z',     default='0.0')
-    cam_roll = LaunchConfiguration('cam_roll',      default='0.0')
-    cam_pitch = LaunchConfiguration('cam_pitch',     default='0.0')
-    cam_yaw = LaunchConfiguration('cam_yaw',       default='0.0')
 
     mode = LaunchConfiguration('mode', default='depth')
     lrcheck = LaunchConfiguration('lrcheck', default=True)
@@ -56,58 +44,11 @@ def generate_launch_description():
                                         choices=['standard', 'lite'],
                                         description='Turtlebot4 Model')
 
-    declare_camera_model_cmd = DeclareLaunchArgument(
-        'camera_model',
-        default_value=camera_model,
-        description='The model of the camera. Using a wrong camera model can disable camera features. \
-                     Valid models: `OAK-D, OAK-D-LITE`.')
-
     declare_camera_name_cmd = DeclareLaunchArgument(
         'camera_name',
         default_value=camera_name,
         description='The name of the camera. It can be different from the camera model \
                      and it will be used in naming TF.')
-
-    declare_base_frame_cmd = DeclareLaunchArgument(
-        'base_frame',
-        default_value=base_frame,
-        description='Name of the base link.')
-
-    declare_parent_frame_cmd = DeclareLaunchArgument(
-        'parent_frame',
-        default_value=parent_frame,
-        description='Name of the parent link from other a robot TF for example \
-                     that can be connected to the base of the OAK.')
-
-    declare_pos_x_cmd = DeclareLaunchArgument(
-        'cam_pos_x',
-        default_value=cam_pos_x,
-        description='Position X of the camera with respect to the base frame.')
-
-    declare_pos_y_cmd = DeclareLaunchArgument(
-        'cam_pos_y',
-        default_value=cam_pos_y,
-        description='Position Y of the camera with respect to the base frame.')
-
-    declare_pos_z_cmd = DeclareLaunchArgument(
-        'cam_pos_z',
-        default_value=cam_pos_z,
-        description='Position Z of the camera with respect to the base frame.')
-
-    declare_roll_cmd = DeclareLaunchArgument(
-        'cam_roll',
-        default_value=cam_roll,
-        description='Roll orientation of the camera with respect to the base frame.')
-
-    declare_pitch_cmd = DeclareLaunchArgument(
-        'cam_pitch',
-        default_value=cam_pitch,
-        description='Pitch orientation of the camera with respect to the base frame.')
-
-    declare_yaw_cmd = DeclareLaunchArgument(
-        'cam_yaw',
-        default_value=cam_yaw,
-        description='Yaw orientation of the camera with respect to the base frame.')
 
     declare_mode_cmd = DeclareLaunchArgument(
         'mode',
@@ -135,22 +76,9 @@ def generate_launch_description():
         'LRchecktresh',
         default_value=LRchecktresh)
 
-    urdf_launch = IncludeLaunchDescription(
-                            launch_description_sources.PythonLaunchDescriptionSource(
-                                    os.path.join(urdf_launch_dir, 'urdf_launch.py')),
-                            launch_arguments={'camera_name': camera_name,
-                                              'camera_model': camera_model,
-                                              'base_frame': base_frame,
-                                              'parent_frame': parent_frame,
-                                              'cam_pos_x': cam_pos_x,
-                                              'cam_pos_y': cam_pos_y,
-                                              'cam_pos_z': cam_pos_z,
-                                              'cam_roll': cam_roll,
-                                              'cam_pitch': cam_pitch,
-                                              'cam_yaw': cam_yaw}.items())
-
-    stereo_node = launch_ros.actions.Node(
-            package='depthai_examples', executable='stereo_node',
+    stereo_node = Node(
+            package='depthai_examples',
+            executable='stereo_node',
             output='screen',
             parameters=[{'camera_name': camera_name},
                         {'mode': mode},
@@ -158,16 +86,34 @@ def generate_launch_description():
                         {'extended': extended},
                         {'subpixel': subpixel}])
 
-    oakd_standard_stf = launch_ros.actions.Node(
+    oakd_left_standard_stf = Node(
             name='oakd_standard_stf',
             package='tf2_ros',
             executable='static_transform_publisher',
             output='screen',
-            arguments=['-0.0596', '0', '0.17933', '0', '0', '0', 'base_link', 'oak-d-base-frame'],
+            arguments=['-0.0596', '0', '0.17933', '0', '0', '0', 'base_link', 'oak_left_camera_optical_frame'],
             condition=LaunchConfigurationEquals('model', 'standard')
         )
 
-    oakd_lite_stf = launch_ros.actions.Node(
+    oakd_right_standard_stf = Node(
+            name='oakd_standard_stf',
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            output='screen',
+            arguments=['-0.0596', '0', '0.17933', '0', '0', '0', 'base_link', 'oak_right_camera_optical_frame'],
+            condition=LaunchConfigurationEquals('model', 'standard')
+        )
+
+    oakd_rgb_standard_stf = Node(
+            name='oakd_standard_stf',
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            output='screen',
+            arguments=['-0.0596', '0', '0.17933', '0', '0', '0', 'base_link', 'oak_rgb_camera_optical_frame'],
+            condition=LaunchConfigurationEquals('model', 'standard')
+        )
+
+    oakd_lite_stf = Node(
             name='oakd_lite_stf',
             package='tf2_ros',
             executable='static_transform_publisher',
@@ -179,17 +125,6 @@ def generate_launch_description():
     ld = LaunchDescription()
     ld.add_action(robot_model)
     ld.add_action(declare_camera_name_cmd)
-    ld.add_action(declare_camera_model_cmd)
-
-    ld.add_action(declare_base_frame_cmd)
-    ld.add_action(declare_parent_frame_cmd)
-
-    ld.add_action(declare_pos_x_cmd)
-    ld.add_action(declare_pos_y_cmd)
-    ld.add_action(declare_pos_z_cmd)
-    ld.add_action(declare_roll_cmd)
-    ld.add_action(declare_pitch_cmd)
-    ld.add_action(declare_yaw_cmd)
 
     ld.add_action(declare_mode_cmd)
     ld.add_action(declare_lrcheck_cmd)
@@ -199,8 +134,9 @@ def generate_launch_description():
     ld.add_action(declare_LRchecktresh_cmd)
 
     ld.add_action(stereo_node)
-    ld.add_action(urdf_launch)
-    ld.add_action(oakd_standard_stf)
+    ld.add_action(oakd_left_standard_stf)
+    ld.add_action(oakd_right_standard_stf)
+    ld.add_action(oakd_rgb_standard_stf)
     ld.add_action(oakd_lite_stf)
 
     return ld

--- a/turtlebot4_bringup/launch/standard.launch.py
+++ b/turtlebot4_bringup/launch/standard.launch.py
@@ -28,6 +28,7 @@ def generate_launch_description():
 
     pkg_turtlebot4_bringup = get_package_share_directory('turtlebot4_bringup')
     pkg_turtlebot4_diagnostics = get_package_share_directory('turtlebot4_diagnostics')
+    pkg_turtlebot4_description = get_package_share_directory('turtlebot4_description')
 
     param_file_cmd = DeclareLaunchArgument(
         'param_file',
@@ -49,6 +50,9 @@ def generate_launch_description():
         [pkg_turtlebot4_bringup, 'launch', 'rplidar.launch.py'])
     oakd_launch_file = PathJoinSubstitution(
         [pkg_turtlebot4_bringup, 'launch', 'oakd.launch.py'])
+    description_launch_file = PathJoinSubstitution(
+        [pkg_turtlebot4_description, 'launch', 'description.launch.py']
+    )
 
     standard_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([turtlebot4_robot_launch_file]),
@@ -62,6 +66,10 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([rplidar_launch_file]))
     oakd_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([oakd_launch_file]))
+    description_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([description_launch_file]),
+        launch_arguments=[('model', 'standard')]
+    )
 
     ld = LaunchDescription()
     ld.add_action(param_file_cmd)
@@ -70,4 +78,5 @@ def generate_launch_description():
     ld.add_action(diagnostics_launch)
     ld.add_action(rplidar_launch)
     ld.add_action(oakd_launch)
+    ld.add_action(description_launch)
     return ld

--- a/turtlebot4_bringup/launch/standard.launch.py
+++ b/turtlebot4_bringup/launch/standard.launch.py
@@ -51,7 +51,7 @@ def generate_launch_description():
     oakd_launch_file = PathJoinSubstitution(
         [pkg_turtlebot4_bringup, 'launch', 'oakd.launch.py'])
     description_launch_file = PathJoinSubstitution(
-        [pkg_turtlebot4_description, 'launch', 'description.launch.py']
+        [pkg_turtlebot4_description, 'launch', 'robot_description.launch.py']
     )
 
     standard_launch = IncludeLaunchDescription(


### PR DESCRIPTION
## Description

- With https://github.com/turtlebot/turtlebot4/pull/6 merged, we will be able to launch the robot description from the robot itself.
- Removed robot_state_publisher from oakd launch.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
# Run this command
ros2 launch turtlebot4_bringup standard.launch.py
ros2 launch turtlebot4_bringup lite.launch.py
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation