### PR TITLE
Separate diagnostics to use RPLiDAR auto standby mode

### DIFF
--- a/turtlebot4_bringup/launch/lite.launch.py
+++ b/turtlebot4_bringup/launch/lite.launch.py
@@ -18,13 +18,17 @@
 
 from ament_index_python.packages import get_package_share_directory
 
-from launch import LaunchDescription
+from launch import LaunchContext, LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, SetEnvironmentVariable
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration, PathJoinSubstitution
 
 
 def generate_launch_description():
+    lc = LaunchContext()
+    ld = LaunchDescription()
+
+    diagnostics_enable = EnvironmentVariable('TURTLEBOT4_DIAGNOSTICS', default_value='true')
 
     pkg_turtlebot4_bringup = get_package_share_directory('turtlebot4_bringup')
     pkg_turtlebot4_diagnostics = get_package_share_directory('turtlebot4_diagnostics')
@@ -71,11 +75,12 @@ def generate_launch_description():
         launch_arguments=[('model', 'lite')]
     )
 
-    ld = LaunchDescription()
+    if (diagnostics_enable.perform(lc)) == 'true':
+        ld.add_action(diagnostics_launch)
+
     ld.add_action(param_file_cmd)
     ld.add_action(lite_launch)
     ld.add_action(teleop_launch)
-    ld.add_action(diagnostics_launch)
     ld.add_action(rplidar_launch)
     ld.add_action(oakd_launch)
     ld.add_action(description_launch)

--- a/turtlebot4_bringup/launch/lite.launch.py
+++ b/turtlebot4_bringup/launch/lite.launch.py
@@ -28,7 +28,7 @@ def generate_launch_description():
     lc = LaunchContext()
     ld = LaunchDescription()
 
-    diagnostics_enable = EnvironmentVariable('TURTLEBOT4_DIAGNOSTICS', default_value='true')
+    diagnostics_enable = EnvironmentVariable('TURTLEBOT4_DIAGNOSTICS', default_value='1')
 
     pkg_turtlebot4_bringup = get_package_share_directory('turtlebot4_bringup')
     pkg_turtlebot4_diagnostics = get_package_share_directory('turtlebot4_diagnostics')
@@ -75,7 +75,7 @@ def generate_launch_description():
         launch_arguments=[('model', 'lite')]
     )
 
-    if (diagnostics_enable.perform(lc)) == 'true':
+    if (diagnostics_enable.perform(lc)) == '1':
         ld.add_action(diagnostics_launch)
 
     ld.add_action(param_file_cmd)

--- a/turtlebot4_bringup/launch/lite.launch.py
+++ b/turtlebot4_bringup/launch/lite.launch.py
@@ -41,6 +41,8 @@ def generate_launch_description():
 
     turtlebot4_robot_launch_file = PathJoinSubstitution(
         [pkg_turtlebot4_bringup, 'launch', 'robot.launch.py'])
+    joy_teleop_launch_file = PathJoinSubstitution(
+        [pkg_turtlebot4_bringup, 'launch', 'joy_teleop.launch.py'])
     diagnostics_launch_file = PathJoinSubstitution(
         [pkg_turtlebot4_diagnostics, 'launch', 'diagnostics.launch.py'])
     rplidar_launch_file = PathJoinSubstitution(
@@ -55,6 +57,8 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([turtlebot4_robot_launch_file]),
         launch_arguments=[('model', 'lite'),
                           ('param_file', turtlebot4_param_yaml_file)])
+    teleop_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([joy_teleop_launch_file]))
     diagnostics_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([diagnostics_launch_file]))
     rplidar_launch = IncludeLaunchDescription(
@@ -70,6 +74,7 @@ def generate_launch_description():
     ld = LaunchDescription()
     ld.add_action(param_file_cmd)
     ld.add_action(lite_launch)
+    ld.add_action(teleop_launch)
     ld.add_action(diagnostics_launch)
     ld.add_action(rplidar_launch)
     ld.add_action(oakd_launch)

--- a/turtlebot4_bringup/launch/rplidar.launch.py
+++ b/turtlebot4_bringup/launch/rplidar.launch.py
@@ -31,6 +31,7 @@ def generate_launch_description():
                 'frame_id': 'rplidar_link',
                 'inverted': False,
                 'angle_compensate': True,
+                'auto_standby': True,
             }],
         )
 

--- a/turtlebot4_bringup/launch/standard.launch.py
+++ b/turtlebot4_bringup/launch/standard.launch.py
@@ -18,13 +18,17 @@
 
 from ament_index_python.packages import get_package_share_directory
 
-from launch import LaunchDescription
+from launch import LaunchContext, LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, SetEnvironmentVariable
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration, PathJoinSubstitution
 
 
 def generate_launch_description():
+    lc = LaunchContext()
+    ld = LaunchDescription()
+
+    diagnostics_enable = EnvironmentVariable('TURTLEBOT4_DIAGNOSTICS', default_value='true')
 
     pkg_turtlebot4_bringup = get_package_share_directory('turtlebot4_bringup')
     pkg_turtlebot4_diagnostics = get_package_share_directory('turtlebot4_diagnostics')
@@ -69,13 +73,15 @@ def generate_launch_description():
         launch_arguments=[('tf_prefix', 'oakd_pro')])
     description_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([description_launch_file]),
-        launch_arguments=[('model', 'standard')])
+        launch_arguments=[('model', 'standard')]
+    )
 
-    ld = LaunchDescription()
+    if (diagnostics_enable.perform(lc)) == 'true':
+        ld.add_action(diagnostics_launch)
+
     ld.add_action(param_file_cmd)
     ld.add_action(standard_launch)
     ld.add_action(teleop_launch)
-    ld.add_action(diagnostics_launch)
     ld.add_action(rplidar_launch)
     ld.add_action(oakd_launch)
     ld.add_action(description_launch)

--- a/turtlebot4_bringup/launch/standard.launch.py
+++ b/turtlebot4_bringup/launch/standard.launch.py
@@ -28,7 +28,7 @@ def generate_launch_description():
     lc = LaunchContext()
     ld = LaunchDescription()
 
-    diagnostics_enable = EnvironmentVariable('TURTLEBOT4_DIAGNOSTICS', default_value='true')
+    diagnostics_enable = EnvironmentVariable('TURTLEBOT4_DIAGNOSTICS', default_value='1')
 
     pkg_turtlebot4_bringup = get_package_share_directory('turtlebot4_bringup')
     pkg_turtlebot4_diagnostics = get_package_share_directory('turtlebot4_diagnostics')
@@ -76,7 +76,7 @@ def generate_launch_description():
         launch_arguments=[('model', 'standard')]
     )
 
-    if (diagnostics_enable.perform(lc)) == 'true':
+    if (diagnostics_enable.perform(lc)) == '1':
         ld.add_action(diagnostics_launch)
 
     ld.add_action(param_file_cmd)


### PR DESCRIPTION
## Description

- Enable/disable diagnostics based on TURTLEBOT4_DIAGNOSTICS environment variable.
- Enable auto standby mode in RPLiDAR launch file.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

Test #1:
- Enable diagnostics and verify that RPLiDAR spins (because subscriber count > 0)
- Disable diagnostics and verify that RPLiDAR stops spinning (because subscriber count == 0).
- Disable diagnostics, verify that RPLiDAR motor stops spinning, launch `slam_sync.launch.py`, verify that RPLiDAR spins, and generate map.

```bash
# Run this command
ros2 run turtlebot4_setup turtlebot4_setup # Enable/disable diagnostics
ros2 launch turtlebot4_bringup lite.launch.py # TTB4 Lite base nodes
ros2 launch turtlebot4_navigation slam_sync.launch.py # SLAM
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation