### PR TITLE
Launch create3 republisher for discovery server

### DIFF
--- a/turtlebot4_bringup/launch/robot.launch.py
+++ b/turtlebot4_bringup/launch/robot.launch.py
@@ -15,6 +15,7 @@
 #
 # @author Roni Kreinin (rkreinin@clearpathrobotics.com)
 
+import os
 
 from ament_index_python.packages import get_package_share_directory
 
@@ -72,7 +73,6 @@ def generate_launch_description():
         output='screen',
         condition=LaunchConfigurationEquals('model', 'standard')
     )
-
     create3_republisher_node = Node(
         package='create3_republisher',
         executable='create3_republisher',
@@ -86,5 +86,6 @@ def generate_launch_description():
     ld.add_action(create3_param_file_cmd)
     ld.add_action(turtlebot4_node)
     ld.add_action(turtlebot4_base_node)
-    ld.add_action(create3_republisher_node)
+    if (os.environ.get('ROS_DISCOVERY_SERVER', '').strip(' ;\"')):
+        ld.add_action(create3_republisher_node)
     return ld

--- a/turtlebot4_bringup/launch/robot.launch.py
+++ b/turtlebot4_bringup/launch/robot.launch.py
@@ -39,6 +39,7 @@ ARGUMENTS = [
 def generate_launch_description():
 
     pkg_turtlebot4_bringup = get_package_share_directory('turtlebot4_bringup')
+    create3_republisher = get_package_share_directory('create3_republisher')
 
     param_file_cmd = DeclareLaunchArgument(
         'param_file',
@@ -47,7 +48,15 @@ def generate_launch_description():
         description='Turtlebot4 Robot param file'
     )
 
+    create3_param_file_cmd = DeclareLaunchArgument(
+        'create3_param_file',
+        default_value=PathJoinSubstitution(
+            [create3_republisher, 'bringup', 'params.yaml']),
+        description='Create3 republisher param file'
+    )
+
     turtlebot4_param_yaml_file = LaunchConfiguration('param_file')
+    create3_repub_param_yaml_file = LaunchConfiguration('create3_param_file')
 
     turtlebot4_node = Node(
         package='turtlebot4_node',
@@ -64,8 +73,18 @@ def generate_launch_description():
         condition=LaunchConfigurationEquals('model', 'standard')
     )
 
+    create3_republisher_node = Node(
+        package='create3_republisher',
+        executable='create3_republisher',
+        parameters=[create3_repub_param_yaml_file,
+                    {'robot_namespace': '_do_not_use'}],
+        output='screen',
+    )
+
     ld = LaunchDescription(ARGUMENTS)
     ld.add_action(param_file_cmd)
+    ld.add_action(create3_param_file_cmd)
     ld.add_action(turtlebot4_node)
     ld.add_action(turtlebot4_base_node)
+    ld.add_action(create3_republisher_node)
     return ld

--- a/turtlebot4_bringup/package.xml
+++ b/turtlebot4_bringup/package.xml
@@ -21,6 +21,7 @@
   <depend>nav2_common</depend>
   <depend>teleop_twist_joy</depend>
   <depend>tf2_ros</depend>
+  <depend>create3_republisher</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Description

Adds create3 republisher launch to support multi-robot discovery server. Required for https://github.com/turtlebot/turtlebot4_setup/pull/11

## Type of change

- [x] Bug fix
- [x] New feature

Breaking changes - with this latest release, anyone who runs discovery server needs to re-run the turtlebot4-setup tool

## How Has This Been Tested?

Updated on the robot and then tested that the create3 republisher launches and all basic functionality works. 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation